### PR TITLE
Move grunt from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "grunt": "~0.4.1",
     "handlebars": "~1.3.0",
     "highlight.js": "~7.4.0",
     "iconv-lite": "~0.2.11",
@@ -53,7 +54,6 @@
   },
   "devDependencies": {
     "chai": "~1.8.1",
-    "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compress": "~0.5.2",
     "grunt-contrib-jshint": "~0.7.1",


### PR DESCRIPTION
Right now, it's not possible to use this module as non-dev dependency because grunt won't be installed. This change would fix that.

However, there might be a reason for this structure that I'm not aware of.