### PR TITLE
Get the sum to attempt to parse before it gives up

### DIFF
--- a/lib/helpers/helpers-math.js
+++ b/lib/helpers/helpers-math.js
@@ -41,14 +41,13 @@ var helpers = {
     return Math.round(value);
   },
 
+  // Attempt to parse the int, if not class it as 0
   sum: function () {
     var args = _.flatten(arguments);
     var sum = 0;
     var i = args.length - 1;
     while (i--) {
-      if ("number" === typeof args[i]) {
-        sum += args[i];
-      }
+      sum +=  _.parseInt(args[i]) || 0;
     }
     return Number(sum);
   }

--- a/test/helpers/math_test.js
+++ b/test/helpers/math_test.js
@@ -105,6 +105,18 @@ describe('sum', function() {
 });
 
 describe('sum', function() {
+  describe('{{sum "value" 10}}', function() {
+    it('should return the sum of multiple numbers.', function() {
+      var source = '{{sum value 10}}';
+      var template = Handlebars.compile(source);
+      template(context = {
+        value: "20"
+      }).should.equal('30');
+    });
+  });
+});
+
+describe('sum', function() {
   describe('{{sum 1 2 3}}', function() {
     it('should return the sum of multiple numbers.', function() {
       var source = '{{sum 1 2 3}}';


### PR DESCRIPTION
Previously the sum helper would ignore anything that wasn't a number and move on, this is a problem as some helpers pass as a string when used like this - `{{sum (now "%Y") 10}}`

As Lodash is already being used in here, I've taken advantage of the parseInt function, which passes through NaN if it can't turn it to number.