### PR TITLE
Default options object in helpers-markdown.

### DIFF
--- a/lib/helpers/helpers-markdown.js
+++ b/lib/helpers/helpers-markdown.js
@@ -18,6 +18,7 @@ var Glob  = require('../utils/glob');
 
 // Export helpers
 module.exports.register = function (Handlebars, options) {
+  options = options || {};
 
   var opts = {
     gfm: true,


### PR DESCRIPTION
If no options are passed into the helpers-markdown register function, fallback on an empty object so lookups on `options.marked` don't throw errors.