### PR TITLE
Fix inconsistency in config key names for custom handlebars instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function helpers(groups, options) {
   }
 
   options = options || {};
-  var hbs = options.handlebars || require('handlebars');
+  var hbs = options.handlebars || options.hbs || require('handlebars');
 
   define(module.exports, 'handlebars', hbs);
 
@@ -47,7 +47,7 @@ module.exports = function helpers(groups, options) {
 forIn(lib, function(group, key) {
   define(module.exports, key, function(options) {
     options = options || {};
-    var hbs = options.hbs || require('handlebars');
+    var hbs = options.handlebars || options.hbs || require('handlebars');
     define(module.exports, 'handlebars', hbs);
     hbs.registerHelper(group);
     return hbs.helpers;


### PR DESCRIPTION
Currently, to pass in your own handlebars instance, you need to use the `handlebars` configuration key to get _all_ helpers:

```
var helpers = require('handlebars-helpers')({
  handlebars: handlebars
});
```

But the `hbs` key to use a specific collection:

```
var math = helpers.math({
  hbs: handlebars
});
```

The docs on this are currently incorrect (i.e. suggests the use of `handlebars` as a key in the collection example).

This PR fixes this and provides support for _both_ the `hbs` and the `handlebars` key for 'all helpers' and collections, to ensure backwards compatibility with people's existing implementations.

