### PR TITLE
Update behaviour of {{ifNth}} helper to directly use value given, resolves #228

### DIFF
--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -277,7 +277,7 @@ helpers.ifEven = function(num, options) {
  */
 
 helpers.ifNth = function(a, b, options) {
-  if (b % a === 0) {
+  if (utils.isNumber(a) && utils.isNumber(b) && b % a === 0) {
     return options.fn(this);
   }
   return options.inverse(this);

--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -277,7 +277,7 @@ helpers.ifEven = function(num, options) {
  */
 
 helpers.ifNth = function(a, b, options) {
-  if (++b % a === 0) {
+  if (b % a === 0) {
     return options.fn(this);
   }
   return options.inverse(this);

--- a/test/comparison.js
+++ b/test/comparison.js
@@ -307,7 +307,7 @@ describe('comparison', function() {
 
   describe('ifNth', function() {
     it('should render a custom class on even rows', function() {
-      var source = '{{#each items}}<div {{#ifNth "2" @index}}class="row-alternate"{{/ifNth}}>{{name}}</div>{{/each}}';
+      var source = '{{#each items}}<div{{#ifNth 2 @index}}{{else}} class="row-alternate"{{/ifNth}}>{{name}}</div>{{/each}}';
       var fn = hbs.compile(source);
       var context = {
         items: [
@@ -319,11 +319,11 @@ describe('comparison', function() {
         ]
       };
       assert(fn(context), [
-        '<div >Philip J. Fry</div>',
+        '<div>Philip J. Fry</div>',
         '<div class="row-alternate">Turanga Leela</div>',
-        '<div >Bender Bending Rodriguez</div>',
+        '<div>Bender Bending Rodriguez</div>',
         '<div class="row-alternate">Amy Wong</div>',
-        '<div >Hermes Conrad</div>'
+        '<div>Hermes Conrad</div>'
       ].join(''));
     });
   });


### PR DESCRIPTION
The `ifNth` helper will now render a block if the remainder is zero when operand `a` is divided by `b`. Previously, this parameter was incremented before comparison, which led to incorrectly described and confusing behaviour. #228 

Whilst considering, please note that this is a breaking change, although the implementation now matches the published documentation.
