### PR TITLE
Add quotations to the id of the gist helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ Embed a GitHub Gist using only the id of the Gist
 **Example**
 
 ```handlebars
-{{gist 12345}}
+{{gist "12345"}}
 ```
 
 ### [{{jsfiddle}}](lib/code.js#L72)

--- a/lib/code.js
+++ b/lib/code.js
@@ -46,7 +46,7 @@ helpers.embed = function embed(fp, ext) {
  * Embed a GitHub Gist using only the id of the Gist
  *
  * ```handlebars
- * {{gist 12345}}
+ * {{gist "12345"}}
  * ```
  * @param  {String} `id`
  * @return {String}


### PR DESCRIPTION
The test code for the gist helper surrounds the id with quotation marks
to treat the id as a string but the documentation and function
description do not. Implementing the example without quotation marks
results in <script src="https://gist.github.com/undefined.js"></script>
being returned.